### PR TITLE
Enable inline animation in 3D GPU pipeline example

### DIFF
--- a/basic_3D_GPU_pipeline_example.ipynb
+++ b/basic_3D_GPU_pipeline_example.ipynb
@@ -35,6 +35,7 @@
     "import matplotlib.pyplot as plt\n",
     "from matplotlib.animation import FuncAnimation\n",
     "from matplotlib.patches import Polygon\n",
+    "from IPython.display import HTML\n",
     "\n",
     "x_res, y_res = 800, 640\n",
     "\n",
@@ -93,8 +94,7 @@
     "    return polys\n",
     "\n",
     "ani = FuncAnimation(fig, update, frames=360, interval=1000/60, blit=True)\n",
-    "plt.show()\n",
-    "\n"
+    "HTML(ani.to_jshtml())\n"
    ]
   }
  ],


### PR DESCRIPTION
## Summary
- ensure 3D cube animation is displayed inline by importing `HTML` and rendering the animation via `ani.to_jshtml()`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6895070426fc8324a8cba554b522d8c7