### PR TITLE
Add textured cube example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Basic GPU Pipeline Example
 
-This project provides simplified examples of a GPU pipeline for educational purposes. It demonstrates the interactions between memory and the vertex shader, tiler, rasterisation and fragment shader pipeline stages and other components commonly found in GPU HW architectures. The repository now contains both a 2D triangle example and a minimal 3D cube rendered from a side perspective.
+This project provides simplified examples of a GPU pipeline for educational purposes. It demonstrates the interactions between memory and the vertex shader, tiler, rasterisation and fragment shader pipeline stages and other components commonly found in GPU HW architectures. The repository now contains a 2D triangle example, a minimal 3D cube rendered from a side perspective, and a textured cube example that maps an image to each face.
 
 ## Prerequisites
 
@@ -49,7 +49,9 @@ This project provides simplified examples of a GPU pipeline for educational purp
     This will start the Jupyter Notebook and open a browser window. Navigate to the directory where you cloned this project.
 
 2. **Open Notebook**
-    - In the Jupyter Notebook browser window, click on `basic_2D_GPU_pipeline_example.ipynb` for the 2D triangle pipeline or `basic_3D_GPU_pipeline_example.ipynb` to explore the 3D cube example.
+    - In the Jupyter Notebook browser window, click on `basic_2D_GPU_pipeline_example.ipynb` for the 2D triangle pipeline.
+    - Open `basic_3D_GPU_pipeline_example.ipynb` to explore the 3D cube example.
+    - To see a cube with the same image applied as a texture on all faces, run `textured_cube_example.ipynb` (requires you to provide a `texture.jpg` image in the repository root).
 
 3. **Run Notebook**
     - You can run each cell individually by clicking on it and pressing `Shift + Enter`, or run all cells by clicking `Cell > Run All` in the menu.

--- a/textured_cube_example.ipynb
+++ b/textured_cube_example.ipynb
@@ -1,0 +1,70 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "2aa4b414",
+   "metadata": {},
+   "source": [
+    "# Textured Cube Example\n",
+    "\n",
+    "This notebook demonstrates applying a texture to all faces of a rotating cube using Matplotlib's 3D capabilities. Provide your own image file named `texture.jpg` in the repository root before running.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7f76032c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "from mpl_toolkits.mplot3d import Axes3D\n",
+    "from matplotlib.animation import FuncAnimation\n",
+    "from IPython.display import HTML\n",
+    "\n",
+    "# Load the texture image (provide texture.jpg in the repository root)\n",
+    "texture = plt.imread(\"texture.jpg\")\n",
+    "if texture.dtype == np.uint8:\n",
+    "    texture = texture.astype(np.float32) / 255.0\n",
+    "\n",
+    "# Ensure texture is square and manageable in size\n",
+    "size = min(texture.shape[0], texture.shape[1])\n",
+    "texture = texture[:size, :size]\n",
+    "step = max(1, size // 64)\n",
+    "texture = texture[::step, ::step]\n",
+    "M, N, _ = texture.shape\n",
+    "\n",
+    "u = np.linspace(-0.5, 0.5, N)\n",
+    "v = np.linspace(-0.5, 0.5, M)\n",
+    "U, V = np.meshgrid(u, v)\n",
+    "\n",
+    "fig = plt.figure()\n",
+    "ax = fig.add_subplot(111, projection='3d')\n",
+    "ax.axis('off')\n",
+    "ax.set_box_aspect([1,1,1])\n",
+    "\n",
+    "faces = []\n",
+    "# Front and back faces (Y constant)\n",
+    "faces.append(ax.plot_surface(U, 0.5 * np.ones_like(U), V, rstride=1, cstride=1, facecolors=texture))\n",
+    "faces.append(ax.plot_surface(U, -0.5 * np.ones_like(U), V, rstride=1, cstride=1, facecolors=texture))\n",
+    "# Top and bottom faces (Z constant)\n",
+    "faces.append(ax.plot_surface(U, V, 0.5 * np.ones_like(U), rstride=1, cstride=1, facecolors=texture))\n",
+    "faces.append(ax.plot_surface(U, V, -0.5 * np.ones_like(U), rstride=1, cstride=1, facecolors=texture))\n",
+    "# Left and right faces (X constant)\n",
+    "faces.append(ax.plot_surface(0.5 * np.ones_like(U), U, V, rstride=1, cstride=1, facecolors=texture))\n",
+    "faces.append(ax.plot_surface(-0.5 * np.ones_like(U), U, V, rstride=1, cstride=1, facecolors=texture))\n",
+    "\n",
+    "def update(frame):\n",
+    "    ax.view_init(30, frame)\n",
+    "    return faces\n",
+    "\n",
+    "ani = FuncAnimation(fig, update, frames=360, interval=1000/60, blit=False)\n",
+    "HTML(ani.to_jshtml())\n"
+   ]
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- add `textured_cube_example.ipynb` demonstrating a cube with the same image mapped to every face
- document how to supply your own `texture.jpg` image
- remove bundled `texture.jpg`

## Testing
- `python - <<'PY'
import numpy as np
import matplotlib
matplotlib.use('Agg')
import matplotlib.pyplot as plt
from mpl_toolkits.mplot3d import Axes3D
from matplotlib.animation import FuncAnimation
import os

size=64
x = np.linspace(0,1,size)
img = np.dstack([np.outer(x, x)]*3)
plt.imsave('texture.jpg', img)

texture = plt.imread('texture.jpg')
if texture.dtype == np.uint8:
    texture = texture.astype(np.float32)/255.0
size = min(texture.shape[0], texture.shape[1])
texture = texture[:size,:size]
step = max(1, size // 64)
texture = texture[::step, ::step]
M,N,_ = texture.shape
u = np.linspace(-0.5,0.5,N)
v = np.linspace(-0.5,0.5,M)
U,V = np.meshgrid(u,v)
fig = plt.figure()
ax = fig.add_subplot(111, projection='3d')
ax.axis('off')
ax.set_box_aspect([1,1,1])
faces=[]
faces.append(ax.plot_surface(U, 0.5*np.ones_like(U), V, facecolors=texture))
faces.append(ax.plot_surface(U, -0.5*np.ones_like(U), V, facecolors=texture))
faces.append(ax.plot_surface(U, V, 0.5*np.ones_like(U), facecolors=texture))
faces.append(ax.plot_surface(U, V, -0.5*np.ones_like(U), facecolors=texture))
faces.append(ax.plot_surface(0.5*np.ones_like(U), U, V, facecolors=texture))
faces.append(ax.plot_surface(-0.5*np.ones_like(U), U, V, facecolors=texture))

def update(frame):
    ax.view_init(30, frame)
    return faces
ani = FuncAnimation(fig, update, frames=1)
print('executed')
plt.close(fig)
os.remove('texture.jpg')
PY`


------
https://chatgpt.com/codex/tasks/task_e_689508c619ac83248d82c0fab3e985c8