### PR TITLE
Provide helper script for textured cube example

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ This project provides simplified examples of a GPU pipeline for educational purp
     - In the Jupyter Notebook browser window, click on `basic_2D_GPU_pipeline_example.ipynb` for the 2D triangle pipeline.
     - Open `basic_3D_GPU_pipeline_example.ipynb` to explore the 3D cube example.
     - To see a cube with the same image applied as a texture on all faces, run `textured_cube_example.ipynb` (requires you to provide a `texture.jpg` image in the repository root).
+        - You can download a small sample texture by running `./download_texture.sh`, which saves the image as `texture.jpg`.
 
 3. **Run Notebook**
     - You can run each cell individually by clicking on it and pressing `Shift + Enter`, or run all cells by clicking `Cell > Run All` in the menu.

--- a/download_texture.sh
+++ b/download_texture.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# Download a sample texture image for the textured cube example.
+# Usage: ./download_texture.sh [url] [output]
+# Defaults to a small Creative Commons image and saves to texture.jpg.
+set -euo pipefail
+
+url=${1:-https://upload.wikimedia.org/wikipedia/commons/thumb/3/3f/JPEG_example_flower.jpg/256px-JPEG_example_flower.jpg}
+output=${2:-texture.jpg}
+
+curl -L "$url" -o "$output"
+echo "Texture saved to $output"


### PR DESCRIPTION
## Summary
- Add `download_texture.sh` to fetch a sample texture image for the textured cube notebook.
- Document how to use the helper script in `README.md` so users can easily obtain a test texture.

## Testing
- `bash -n download_texture.sh`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68951a109db4832481c989b7540c5805